### PR TITLE
Release/v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ function counter(state = 0, action) {
 
 const store = createStore(
   counter,
-  applyMiddleware(createMemoizeMiddleware()),
+  applyMiddleware(createMemoizeMiddleware({ ttl: 200 })),
 );
 
 store.dispatch(increment());
@@ -104,7 +104,7 @@ const fetchUserRequest = memoize({ ttl: 1000 }, (username) => {
 
 const store = createStore(
   rootReducer,
-  applyMiddleware(createMemoizeMiddleware(), thunk),
+  applyMiddleware(createMemoizeMiddleware({ ttl: 200 }), thunk),
 );
 
 // Component1
@@ -152,8 +152,8 @@ Create a redux [middleware](http://redux.js.org/docs/advanced/Middleware.html).
 #### Arguments
 
 - `globalOpts` _Object <optional>_
-  - _Object_: Default opts for memorize(). 
-  - **Default**: `{ ttl: 200, enabled: true, isEqual: lodash.isEqual }`]
+  - _Object_: Default opts for memorize().
+  - **Default**: `{ ttl:0, enabled: true, isEqual: lodash.isEqual }`]. **ttl is REQUIRED, You SHOULD set a ttl > 0 in millisecond**
   - There is another options `disableTTL`. The default value is `true` on server and `false` on browser. By default, cached action creator will not be evicted by setTimeout with TTL on server in order to prevent memory leak. You can enable it for test purpose.
 
 #### Returns

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ console.info(promise1 === promise2); OUTPUT: true
 setTimeout(() => {
   store.dispatch(memoizeIncrement());
   console.info(store.getState()); // OUTPUT: 4
-}, 200);
+}, 500);
 ```
 
 **It works perfectly with [redux-thunk](https://github.com/gaearon/redux-thunk)**
@@ -145,7 +145,7 @@ Memoize actionCreator and returns a memoized actionCreator. When dispatch action
 
 - (Promise): will be resolved with the result of original actionCreator.
 
-### createMemoizeMiddleware(globalOpts, disableTTL)
+### createMemoizeMiddleware(globalOpts)
 
 Create a redux [middleware](http://redux.js.org/docs/advanced/Middleware.html).
 
@@ -153,7 +153,7 @@ Create a redux [middleware](http://redux.js.org/docs/advanced/Middleware.html).
 
 - `globalOpts` _Object <optional>_
   - _Object_: Default opts for memorize(). 
-  - **Default**: `{ ttl: 0, enabled: true, isEqual: lodash.isEqual }`]
+  - **Default**: `{ ttl: 200, enabled: true, isEqual: lodash.isEqual }`]
   - There is another options `disableTTL`. The default value is `true` on server and `false` on browser. By default, cached action creator will not be evicted by setTimeout with TTL on server in order to prevent memory leak. You can enable it for test purpose.
 
 #### Returns

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-memoize",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Memoize action creator for redux, and let you dispatch common/thunk/promise/async action whenever you want to, without worrying about duplication",
   "main": "lib/index.js",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import lodashIsEqual from 'lodash/isEqual';
 const ACTION_TYPE = '@redux-memoize/action';
 
 const DEFAULT_META = {
-  ttl: 200,
+  ttl: 0,
   enabled: true,
   isEqual: lodashIsEqual,
 };
@@ -28,8 +28,11 @@ function deepGet(map, args, isEqual) {
 }
 
 export default function createMemoizeMiddleware(options = {}) {
+  if (canUseDOM && options.ttl === undefined) {
+    throw new Error('[createMemoizeMiddleware(globalOptions)] globalOptions.ttl is REQUIRED');
+  }
   const {
-    // default disableTTL is true on server side, to prevent memory leak (use GC to remove cache)
+    // default disableTTL is true on server side, to prevent memory leak (use GC to evict cache)
     disableTTL = !canUseDOM,
     ...globalOptions
   } = options;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-/* eslint no-restricted-syntax:0 */
 import lodashIsEqual from 'lodash/isEqual';
 
 const ACTION_TYPE = '@redux-memoize/action';
@@ -18,7 +17,9 @@ const canUseDOM = !!(
 );
 
 function deepGet(map, args, isEqual) {
-  for (const key of map.keys()) {
+  const keys = Array.from(map.keys());
+  for (let i = 0, len = keys.length; i < len; i += 1) {
+    const key = keys[i];
     if (isEqual(key, args)) {
       return map.get(key);
     }
@@ -72,11 +73,12 @@ export default function createMemoizeMiddleware(options = {}) {
   };
   middleware.getAll = () => {
     const result = [];
-    for (const fnCache of cache.values()) {
-      for (const value of fnCache.values()) {
+    const cacheValues = Array.from(cache.values());
+    cacheValues.forEach((fnCache) => {
+      Array.from(fnCache.values()).forEach((value) => {
         result.push(value);
-      }
-    }
+      });
+    });
     return result;
   };
   return middleware;

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -6,7 +6,7 @@ import createMemoizeMiddleware, { memoize } from '../src/index';
 
 function configureStore(reducer) {
   return compose(
-    applyMiddleware(createMemoizeMiddleware(), thunkMiddleware),
+    applyMiddleware(createMemoizeMiddleware({ ttl: 200 }), thunkMiddleware),
   )(createStore)(reducer);
 }
 
@@ -96,7 +96,15 @@ describe('memoize', () => {
 describe('middleware', () => {
   const doDispatch = () => {};
   const doGetState = () => {};
-  const nextHandler = createMemoizeMiddleware()({ dispatch: doDispatch, getState: doGetState });
+  const nextHandler = createMemoizeMiddleware({
+    ttl: 200,
+  })({ dispatch: doDispatch, getState: doGetState });
+
+  it('must throw an error when ttl is not passed', () => {
+    expect(() => {
+      createMemoizeMiddleware();
+    }).toThrow();
+  });
 
   it('must return a function to handle next', () => {
     expect(typeof nextHandler).toBe('function');
@@ -153,7 +161,7 @@ describe('middleware', () => {
             args: [1, 2],
           },
         };
-        const nextHandler1 = createMemoizeMiddleware()({
+        const nextHandler1 = createMemoizeMiddleware({ ttl: 200 })({
           dispatch: (action) => {
             expect(action).toBe(originalAction);
             done();
@@ -170,7 +178,7 @@ describe('middleware', () => {
   describe('handle errors', () => {
     it('must throw if argument is not a function', () => {
       expect(() => {
-        createMemoizeMiddleware()();
+        createMemoizeMiddleware({ ttl: 200 })();
       }).toThrow();
     });
   });
@@ -196,7 +204,7 @@ describe('unit test', () => {
       };
     });
 
-    const memoizeMiddleware = createMemoizeMiddleware();
+    const memoizeMiddleware = createMemoizeMiddleware({ ttl: 200 });
 
     const store = applyMiddleware(
       memoizeMiddleware,
@@ -235,7 +243,7 @@ describe('unit test', () => {
       payload: num,
     }));
 
-    const memoizeMiddleware = createMemoizeMiddleware({ disableTTL: false });
+    const memoizeMiddleware = createMemoizeMiddleware({ ttl: 200, disableTTL: false });
 
     const store = applyMiddleware(
       memoizeMiddleware,
@@ -381,7 +389,7 @@ describe('unit test', () => {
       };
     });
 
-    const memoizeMiddleware = createMemoizeMiddleware();
+    const memoizeMiddleware = createMemoizeMiddleware({ ttl: 200 });
 
     const store = applyMiddleware(
       thunkMiddleware,
@@ -439,6 +447,7 @@ describe('unit test', () => {
     });
 
     const memoizeMiddleware = createMemoizeMiddleware({
+      ttl: 200,
       disableTTL: false,
     });
 
@@ -536,6 +545,7 @@ describe('unit test', () => {
     }
 
     const memoizeMiddleware = createMemoizeMiddleware({
+      ttl: 200,
       disableTTL: false,
     });
 
@@ -594,6 +604,7 @@ describe('unit test', () => {
     }
 
     const memoizeMiddleware = createMemoizeMiddleware({
+      ttl: 200,
       disableTTL: false,
     });
 


### PR DESCRIPTION
- **[BREAK]** Remove default TTL, change it to be a required option when using createMemoizeMiddleware.
- **[IMPROVEMENT]** Use Array.from instead of ForOfStatement